### PR TITLE
Use combined file after beacon application for intermediate transform

### DIFF
--- a/src/bin/intermediate_transform.rs
+++ b/src/bin/intermediate_transform.rs
@@ -11,7 +11,7 @@ use setup_utils::{domain_size, CheckForCorrectness};
 use snark_setup_operator::data_structs::Setup;
 use snark_setup_operator::setup_filename;
 use snark_setup_operator::transcript_data_structs::Transcript;
-use snark_setup_operator::utils::COMBINED_FILENAME;
+use snark_setup_operator::utils::COMBINED_VERIFIED_POK_AND_CORRECTNESS_NEW_CHALLENGE_FILENAME;
 use snark_setup_operator::{
     error::VerifyTranscriptError,
     utils::{create_full_parameters, remove_file_if_exists},
@@ -212,7 +212,10 @@ impl IntermediateTransform {
         remove_file_if_exists(output_filename)?;
         phase2_cli::prepare_phase2(
             output_filename,
-            setup_filename!(COMBINED_FILENAME, setup.setup_id),
+            setup_filename!(
+                COMBINED_VERIFIED_POK_AND_CORRECTNESS_NEW_CHALLENGE_FILENAME,
+                setup.setup_id
+            ),
             phase2_size,
             &parameters,
             if disable_correctness_checks {


### PR DESCRIPTION
By default, the intermediate transform would be done on the result without the beacon-based contribution.
While this is not necessarily an issue for security, it renders the beacon contribution useless.

The beacon contribution is another contribution after all the participants went.
It is based on external randomness (the beacon hash), and, in the case of Nimiq, was obtained by determining a block number on the Bitcoin chain in the future and taking its hash.